### PR TITLE
Fixing rqt_motion_editor name in setup.py.

### DIFF
--- a/rqt_motion_editor/setup.py
+++ b/rqt_motion_editor/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
-    packages=['vigir_rqt_motion_editor'],
+    packages=['rqt_motion_editor'],
     scripts=['scripts/motion_editor'],
     package_dir={'': 'src'}
 )


### PR DESCRIPTION
Fixes building this package from a clean build, otherwise the python install fails trying to find `vigir_rqt_motion_editor`.
